### PR TITLE
fix errant pypi triggers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,7 @@
 name: Release to PyPI
 
 on:
-  pull_request:
-    types:
-      - closed
+  push:
     branches:
       - main
     paths:


### PR DESCRIPTION
Release is being triggered for any PR to main closing,, even if pyproject.toml isn't updated. Hoping this fixes the issue.