### PR TITLE
fix/Deprecate warning for experimental LangChain VectorStore; other bugfixes

### DIFF
--- a/zep_python/experimental/langchain/zep_vectorstore.py
+++ b/zep_python/experimental/langchain/zep_vectorstore.py
@@ -30,6 +30,15 @@ class ZepVectorStore(VectorStore):
         embedding: Optional[Embeddings] = None,
         **kwargs: Any,
     ) -> None:
+        warnings.warn(
+            (
+                "This experimental class has been deprecated. Please use the "
+                "official ZepVectorStore class in the Langchain package."
+            ),
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
         if not isinstance(collection, DocumentCollection):  # type: ignore
             raise ValueError(
                 "collection should be an instance of a Zep DocumentCollection"

--- a/zep_python/zep_client.py
+++ b/zep_python/zep_client.py
@@ -250,6 +250,7 @@ def concat_url(base_url: str, path: str) -> str:
     str
         The joined URL.
     """
+    base_url = base_url.rstrip("/")
     return urljoin(base_url + "/", path.lstrip("/"))
 
 


### PR DESCRIPTION
- LangChain ZepVectorStore deprecation notice
- strip trailing / from base_url
