### PR TITLE
chore: Update release workflow to include `v` in github tag check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Compare pyproject version with tag
         run: |
           TAG_VERSION=${GITHUB_REF#refs/tags/}
-          if [ "$TAG_VERSION" != "$(poetry version --short)" ]; then
+          if [ "$TAG_VERSION" != "v$(poetry version --short)" ]; then
             echo "Tag version $TAG_VERSION does not match the project version $(poetry version --short)"
             exit 1
           fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "zep-python"
-version = "2.0.0-b.0"
+version = "2.0.0-b.1"
 description = "Zep: Fast, scalable building blocks for LLM apps. This is the Python client for the Zep service."
 authors = ["Daniel Chalef <daniel.chalef@private.org>"]
 readme = "README.md"


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->




| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 65cbf9120ace6acff69570a5a52342d81bc1ca44.  | 
|--------|--------|

### Summary:
This PR updates the release workflow to prepend 'v' to the project version before comparing it with the tag version, ensuring correct version matching.

**Key points**:
- Modified `/.github/workflows/release.yml`
- Changed the comparison of `TAG_VERSION` with the project version
- Now prepends 'v' to the project version before comparison


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!--
ELLIPSIS_HIDDEN
-->
