### PR TITLE
feat(Memory): add summary_instruction field

### DIFF
--- a/examples/ecommerce-chainlit/app.py
+++ b/examples/ecommerce-chainlit/app.py
@@ -210,7 +210,7 @@ async def on_message(message: cl.Message):
                     role=cl.user_session.get("user_name"),
                 ),
             ],
-            summary_instruction="Omit user shoe size from the summary",
+            summary_instruction="Do not include shoe sizes.",
         ),
     )
 

--- a/examples/ecommerce-chainlit/app.py
+++ b/examples/ecommerce-chainlit/app.py
@@ -28,7 +28,6 @@ zep = ZepClient(api_key=API_KEY, api_url=ZEP_API_URL)
 
 openai_client = AsyncOpenAI(api_key=OPENAI_API_KEY)
 
-
 welcome_message = """Welcome to the shoe store! I'm here to help you find the perfect pair of shoes."""
 
 base_system_prompt = """You are a friendly shoe sales assistant. You are responsible for both selling shoes and managing customer
@@ -189,7 +188,6 @@ async def classify_ready_for_purchase(session_id: str):
 
 @cl.step(name="OpenAI", type="llm")
 async def call_openai(messages):
-
     response = await openai_client.chat.completions.create(
         model=OPENAI_MODEL,
         temperature=0.1,
@@ -201,7 +199,6 @@ async def call_openai(messages):
 @cl.on_message
 async def on_message(message: cl.Message):
     session_id = cl.user_session.get("session_id")
-
     # Add the user's message to Zep's memory
     await zep.memory.aadd_memory(
         session_id,
@@ -212,7 +209,8 @@ async def on_message(message: cl.Message):
                     content=message.content,
                     role=cl.user_session.get("user_name"),
                 ),
-            ]
+            ],
+            summary_instruction="Omit user shoe size from the summary"
         ),
     )
 

--- a/examples/ecommerce-chainlit/app.py
+++ b/examples/ecommerce-chainlit/app.py
@@ -210,7 +210,7 @@ async def on_message(message: cl.Message):
                     role=cl.user_session.get("user_name"),
                 ),
             ],
-            summary_instruction="Omit user shoe size from the summary"
+            summary_instruction="Omit user shoe size from the summary",
         ),
     )
 

--- a/zep_python/langchain/history.py
+++ b/zep_python/langchain/history.py
@@ -181,7 +181,9 @@ class ZepChatMessageHistory(BaseChatMessageHistory):
             role_type=get_zep_message_role_type(message.type),
             metadata=metadata,
         )
-        zep_memory = Memory(messages=[zep_message], summary_instruction=self.summary_instruction)
+        zep_memory = Memory(
+            messages=[zep_message], summary_instruction=self.summary_instruction
+        )
 
         self._client.memory.add_memory(self.session_id, zep_memory)
 

--- a/zep_python/langchain/history.py
+++ b/zep_python/langchain/history.py
@@ -42,6 +42,8 @@ class ZepChatMessageHistory(BaseChatMessageHistory):
     memory_type : str
         The type of memory to use. Can be "perpetual", "summary_retrieval",
         or "message_window". Defaults to "perpetual".
+    summary_instruction : Optional[str]
+        Additional instruction for generating the summary.
     """
 
     def __init__(
@@ -53,6 +55,7 @@ class ZepChatMessageHistory(BaseChatMessageHistory):
         memory_type: Optional[str] = None,
         ai_prefix: Optional[str] = None,
         human_prefix: Optional[str] = None,
+        summary_instruction: Optional[str] = None,
     ) -> None:
         if zep_client is None:
             self._client = ZepClient(api_url=api_url, api_key=api_key)
@@ -64,6 +67,7 @@ class ZepChatMessageHistory(BaseChatMessageHistory):
 
         self.ai_prefix = ai_prefix or "ai"
         self.human_prefix = human_prefix or "human"
+        self.summary_instruction = summary_instruction
 
     @property
     def messages(self) -> List[BaseMessage]:  # type: ignore
@@ -177,7 +181,7 @@ class ZepChatMessageHistory(BaseChatMessageHistory):
             role_type=get_zep_message_role_type(message.type),
             metadata=metadata,
         )
-        zep_memory = Memory(messages=[zep_message])
+        zep_memory = Memory(messages=[zep_message], summary_instruction=self.summary_instruction)
 
         self._client.memory.add_memory(self.session_id, zep_memory)
 

--- a/zep_python/langchain/history.py
+++ b/zep_python/langchain/history.py
@@ -43,7 +43,7 @@ class ZepChatMessageHistory(BaseChatMessageHistory):
         The type of memory to use. Can be "perpetual", "summary_retrieval",
         or "message_window". Defaults to "perpetual".
     summary_instruction : Optional[str]
-        Additional instruction for generating the summary.
+        Additional instructions for generating dialog summaries.
     """
 
     def __init__(

--- a/zep_python/memory/models.py
+++ b/zep_python/memory/models.py
@@ -119,6 +119,8 @@ class Memory(BaseModel):
     facts : Optional[List[str]]
         Most recent list of facts derived from the session. Included only with
         perpetual memory type.
+    summary_instruction : Optional[str]
+        Additional instruction for generating the summary.
 
     Methods
     -------
@@ -136,6 +138,7 @@ class Memory(BaseModel):
     created_at: Optional[str] = Field(default=None)
     token_count: Optional[int] = Field(default=None)
     facts: Optional[List[str]] = Field(default=None)
+    summary_instruction: Optional[str] = Field(default=None)
 
     def to_dict(self) -> Dict[str, Any]:
         return self.model_dump(exclude_unset=True, exclude_none=True)


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->
> :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 0fc3841c06a8dfd8bbeb55ab13beb74e40d7f7df.

### Summary:
This PR adds a `summary_instruction` field to the `Memory` class in two different files and uses it in various ways to control summary generation.

**Key points**:
- Added `summary_instruction` field to `Memory` class in `/zep_python/memory/models.py` and `/zep_python/langchain/history.py`
- `summary_instruction` is set to 'Omit user shoe size from the summary' in `on_message` function in `/examples/ecommerce-chainlit/app.py`
- `summary_instruction` is set in the `__init__` method of `ZepChatMessageHistory` class
- `summary_instruction` is used when creating a new `Memory` instance in the `add_message` method


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)

<!--
ELLIPSIS_HIDDEN
-->
