### PR TITLE
chore: Default to perpetual memory type if none provided

### DIFF
--- a/zep_python/memory/client.py
+++ b/zep_python/memory/client.py
@@ -638,7 +638,7 @@ class MemoryClient:
             raise ValueError("session_id must be provided")
 
         url = f"/sessions/{session_id}/memory"
-        params = self._gen_get_params(lastn, memory_type)
+        params = self._gen_get_params(lastn, memory_type or "perpetual")
         response = self.client.get(url, params=params)
 
         handle_response(response, f"No memory found for session {session_id}")
@@ -684,7 +684,7 @@ class MemoryClient:
             raise ValueError("session_id must be provided")
 
         url = f"/sessions/{session_id}/memory"
-        params = self._gen_get_params(lastn, memory_type)
+        params = self._gen_get_params(lastn, memory_type or "perpetual")
         response = await self.aclient.get(url, params=params)
 
         handle_response(response, f"No memory found for session {session_id}")

--- a/zep_python/memory/client.py
+++ b/zep_python/memory/client.py
@@ -638,7 +638,7 @@ class MemoryClient:
             raise ValueError("session_id must be provided")
 
         url = f"/sessions/{session_id}/memory"
-        params = self._gen_get_params(lastn, memory_type or "perpetual")
+        params = self._gen_get_params(lastn, memory_type or MemoryType.perpetual.value)
         response = self.client.get(url, params=params)
 
         handle_response(response, f"No memory found for session {session_id}")
@@ -684,7 +684,7 @@ class MemoryClient:
             raise ValueError("session_id must be provided")
 
         url = f"/sessions/{session_id}/memory"
-        params = self._gen_get_params(lastn, memory_type or "perpetual")
+        params = self._gen_get_params(lastn, memory_type or MemoryType.perpetual.value)
         response = await self.aclient.get(url, params=params)
 
         handle_response(response, f"No memory found for session {session_id}")


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->
> :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 3075ad874ec55dc26ffbafd3c345557ff0eb2c20.

### Summary:
This PR updates the `get_memory` and `aget_memory` functions in the `MemoryClient` class to set the `memory_type` to 'perpetual' by default if no value is provided.

**Key points**:
- Updated `get_memory` and `aget_memory` functions in `MemoryClient` class in `/zep_python/memory/client.py`.
- Set `memory_type` to 'perpetual' by default if no value is provided.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)

<!--
ELLIPSIS_HIDDEN
-->
