### PR TITLE
chore: Add ce and cloud specific release workflows

### DIFF
--- a/.github/workflows/release-ce.yml
+++ b/.github/workflows/release-ce.yml
@@ -1,0 +1,40 @@
+name: Release Community SDK to PyPI
+
+on:
+  push:
+    tags: ["v*.*.*"]
+    branches:
+      - community
+env:
+  POETRY_VERSION: "1.8.3"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    if: github.event.release.target_commitish == 'community'
+    permissions:
+      id-token: write
+      contents: write
+    environment:
+      name: release
+      url: https://pypi.org/p/zep-python
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install poetry
+        run: pipx install poetry==$POETRY_VERSION
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache: "poetry"
+      - name: Compare pyproject version with tag
+        run: |
+          TAG_VERSION=${GITHUB_REF#refs/tags/}
+          if [ "$TAG_VERSION" != "v$(poetry version --short)" ]; then
+            echo "Tag version $TAG_VERSION does not match the project version $(poetry version --short)"
+            exit 1
+          fi
+      - name: Build project for distribution
+        run: poetry build
+#      - name: Publish package distributions to PyPI
+#        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release-cloud.yml
+++ b/.github/workflows/release-cloud.yml
@@ -1,8 +1,8 @@
 name: Release to PyPI
 
 on:
-  push:
-    tags: ["v*.*.*"]
+  release:
+    types: [published]
 
 env:
   POETRY_VERSION: "1.8.3"
@@ -10,6 +10,7 @@ env:
 jobs:
   release:
     runs-on: ubuntu-latest
+    if: github.event.release.target_commitish == 'main'
     permissions:
       id-token: write
       contents: write
@@ -34,5 +35,5 @@ jobs:
           fi
       - name: Build project for distribution
         run: poetry build
-      - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+#      - name: Publish package distributions to PyPI
+#        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add separate GitHub Actions workflows for community and cloud SDK releases to PyPI, with publishing steps commented out.
> 
>   - **Workflows**:
>     - Add `release-ce.yml` for community SDK releases, triggered on `community` branch pushes with version tags.
>     - Rename `release.yml` to `release-cloud.yml` for cloud SDK releases, triggered on published releases targeting `main` branch.
>   - **Environment**:
>     - Set `POETRY_VERSION` to `1.8.3` in both workflows.
>   - **Jobs**:
>     - Both workflows run on `ubuntu-latest` and check if the release target commit matches the respective branch (`community` or `main`).
>     - Include steps to install Poetry, set up Python 3.10, compare tag and project versions, and build the project.
>     - Comment out the step to publish package distributions to PyPI in both workflows.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fzep-python&utm_source=github&utm_medium=referral)<sup> for aa3cf0ac958a2eec6b653106379d2d655f34bf13. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->