### PR TITLE
chore: Enable pypi publish

### DIFF
--- a/.github/workflows/release-ce.yml
+++ b/.github/workflows/release-ce.yml
@@ -35,5 +35,5 @@ jobs:
           fi
       - name: Build project for distribution
         run: poetry build
-#      - name: Publish package distributions to PyPI
-#        uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release-cloud.yml
+++ b/.github/workflows/release-cloud.yml
@@ -1,4 +1,4 @@
-name: Release to PyPI
+name: Release Cloud SDK to PyPI
 
 on:
   release:
@@ -35,5 +35,5 @@ jobs:
           fi
       - name: Build project for distribution
         run: poetry build
-#      - name: Publish package distributions to PyPI
-#        uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enable PyPI publishing for Community and Cloud SDKs by updating GitHub Actions workflows.
> 
>   - **Workflows**:
>     - Enable PyPI publishing in `.github/workflows/release-ce.yml` by uncommenting the `pypa/gh-action-pypi-publish@release/v1` step.
>     - Enable PyPI publishing in `.github/workflows/release-cloud.yml` by uncommenting the `pypa/gh-action-pypi-publish@release/v1` step.
>   - **Misc**:
>     - Rename workflow in `release-cloud.yml` from "Release to PyPI" to "Release Cloud SDK to PyPI".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fzep-python&utm_source=github&utm_medium=referral)<sup> for e91f434b8990ffab9d4eb74181a450dd7d7bd7ca. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->