### PR TITLE
Prepare Python SDK release automation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: ci
 
-on: [push]
+on:
+  push:
+    branches: [main]
+  pull_request:
 jobs:
   compile:
     runs-on: ubuntu-24.04

--- a/.github/workflows/release-cloud.yml
+++ b/.github/workflows/release-cloud.yml
@@ -10,7 +10,6 @@ env:
 jobs:
   release:
     runs-on: ubuntu-latest
-    if: github.event.release.target_commitish == 'main' || github.event.release.target_commitish == 'v3'
     permissions:
       id-token: write
       contents: write
@@ -20,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install poetry
-        run: pipx install poetry==$POETRY_VERSION
+        run: pipx install "poetry==$POETRY_VERSION"
       - name: Set up Python 3.10
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## Summary

- run SDK validation on pull requests while retaining pushes to `main`
- let release jobs publish the checked-out release tag instead of filtering on `target_commitish`
- quote the Poetry version expansion so the workflow passes shell validation

## Motivation

The monorepo SDK release orchestrator must be able to wait for CI on Fern-generated pull requests and publish a release from the exact merged commit. GitHub release `target_commitish` is metadata and is not a reliable release-integrity gate; the workflow already checks out the release tag and verifies that its version matches `pyproject.toml`.

## Validation

- `actionlint .github/workflows/ci.yml .github/workflows/release-cloud.yml`
- `git diff --check`

## Impact

No SDK runtime code changes. This prepares the Python repository for orchestrated SDK releases.
